### PR TITLE
Use variables rather than reply on copy and paste.

### DIFF
--- a/audit/get-event-types.sh
+++ b/audit/get-event-types.sh
@@ -3,4 +3,4 @@
 source "../../config.sh"
 
 curl -X "OPTIONS" "https://api.nexmo.com/beta/audit/events" \
-     -u 'NEXMO_API_KEY:NEXMO_API_SECRET'
+     -u '$NEXMO_API_KEY:$NEXMO_API_SECRET'

--- a/audit/get-event-types.sh
+++ b/audit/get-event-types.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "../../config.sh"
+source "../config.sh"
 
 curl -X "OPTIONS" "https://api.nexmo.com/beta/audit/events" \
-     -u '$NEXMO_API_KEY:$NEXMO_API_SECRET'
+     -u "$NEXMO_API_KEY:$NEXMO_API_SECRET"

--- a/audit/get-event.sh
+++ b/audit/get-event.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-source "../../config.sh"
+source "../config.sh"
 
 curl "https://api.nexmo.com/beta/audit/events/$EVENT_UUID" \
-     -u '$NEXMO_API_KEY:$NEXMO_API_SECRET'
+     -u "$NEXMO_API_KEY:$NEXMO_API_SECRET"
 

--- a/audit/get-event.sh
+++ b/audit/get-event.sh
@@ -2,6 +2,6 @@
 
 source "../../config.sh"
 
-curl "https://api.nexmo.com/beta/audit/events/EVENT_UUID" \
-     -u 'NEXMO_API_KEY:NEXMO_API_SECRET'
+curl "https://api.nexmo.com/beta/audit/events/$EVENT_UUID" \
+     -u '$NEXMO_API_KEY:$NEXMO_API_SECRET'
 

--- a/audit/get-events-with-filtering.sh
+++ b/audit/get-events-with-filtering.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-source "../../config.sh"
-
-SEARCH_TEXT='password'
-DATE_FROM='2018-07-01'
-DATE_TO='2018-08-01'
+source "../config.sh"
 
 curl "https://api.nexmo.com/beta/audit/events?search_text=$SEARCH_TEXT&date_from=$DATE_FROM&date_to=$DATE_TO" \
-     -u '$NEXMO_API_KEY:$NEXMO_API_SECRET'
+     -u "$NEXMO_API_KEY:$NEXMO_API_SECRET"

--- a/audit/get-events-with-filtering.sh
+++ b/audit/get-events-with-filtering.sh
@@ -2,9 +2,9 @@
 
 source "../../config.sh"
 
-SEARCH_TEXT = 'password'
-DATE_FROM = '2018-07-01'
-DATE_TO = '2018-08-01'
+SEARCH_TEXT='password'
+DATE_FROM='2018-07-01'
+DATE_TO='2018-08-01'
 
-curl "https://api.nexmo.com/beta/audit/events?search_text=SEARCH_TEXT&date_from=DATE_FROM&date_to=DATE_TO" \
-     -u 'NEXMO_API_KEY:NEXMO_API_SECRET'
+curl "https://api.nexmo.com/beta/audit/events?search_text=$SEARCH_TEXT&date_from=$DATE_FROM&date_to=$DATE_TO" \
+     -u '$NEXMO_API_KEY:$NEXMO_API_SECRET'

--- a/audit/get-events.sh
+++ b/audit/get-events.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "../../config.sh"
+source "../config.sh"
 
 curl "https://api.nexmo.com/beta/audit/events" \
-     -u '$NEXMO_API_KEY:$NEXMO_API_SECRET'
+     -u "$NEXMO_API_KEY:$NEXMO_API_SECRET"

--- a/audit/get-events.sh
+++ b/audit/get-events.sh
@@ -3,4 +3,4 @@
 source "../../config.sh"
 
 curl "https://api.nexmo.com/beta/audit/events" \
-     -u 'NEXMO_API_KEY:NEXMO_API_SECRET'
+     -u '$NEXMO_API_KEY:$NEXMO_API_SECRET'

--- a/config.sh
+++ b/config.sh
@@ -15,6 +15,9 @@ SECRET_ID=""
 
 # Audit API
 EVENT_UUID=""  # UUID of audit event
+SEARCH_TEXT="number"
+DATE_FROM="2018-07-01"
+DATE_TO="2018-08-01"
 
 # If we have a local config, override using that
 CONFIG_DIR=$(dirname "${BASH_SOURCE[0]}")


### PR DESCRIPTION
# Description

Was relying on copy and pasting of key values rather than using environment variables. Using environment variables is the correct approach. 